### PR TITLE
Replace `pipx` with `pip` and a virutal environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,39 @@
 FROM gcc:14.2.0@sha256:4f7f4804d6fa49c371f0f3f54e72a352d865baa6917e79cff63d2b860c53197b
+
 RUN apt-get update && \
     apt-get install -y \
     libboost-iostreams-dev=1.74.0.3 \
     libtbb-dev=2021.8.0-2 \
     libblosc-dev=1.21.3+ds-1 \
-    cmake \
-    python3 \
-    python3-pybind11 \
-    python3-dev
-    # TODO: pin all unpinned versions
+    cmake=3.25.1-1 \
+    python3-pybind11=2.10.3-1 \
+    # TODO: Split to multistage build
+    python3-venv=3.11.2-1+b1 \
+    python3-pip=23.0.1+dfsg-1
 
 RUN git clone https://github.com/AcademySoftwareFoundation/openvdb.git && \
     cd openvdb && \
     mkdir build && \
     cd build && \
     cmake .. -D OPENVDB_BUILD_PYTHON_MODULE=ON && \
-    make && \ 
+    make && \
     make install
-    
-RUN apt-get install -y python3-pip pipx
 
 RUN useradd -ms /bin/bash nonroot
+
 USER nonroot
 
+WORKDIR /home/nonroot
+
 COPY neurovolume_deps.txt .
-RUN cat neurovolume_deps.txt | while read package; do pipx install --include-deps $package; done
+
+# This path doesn't exist yet; we create it in the next layer
+ENV PATH="/home/nonroot/.venv/bin:$PATH"
+
+RUN python3 -m venv .venv && \
+    # TODO: Parametrize?
+    pip install -r neurovolume_deps.txt
+
+ENV PYTHONPATH="/openvdb/build/openvdb/openvdb/python"
 
 ENTRYPOINT [ "sleep", "infinity" ]


### PR DESCRIPTION
Adapting this description from our Zulip thread in case others are curious.

## Background

We're trying to use `pip` to install packages in a `gcc` image. That image is running on a `linuxkit` build that implements 
 [PEP 668](https://peps.python.org/pep-0668/). This has caused us some headaches as my usual lazy way of installing packages could potentially conflict with systems packages. This is less of a concern in containers; as [even the Python documentation notes](https://packaging.python.org/en/latest/specifications/externally-managed-environments/#externally-managed-environments):

> In certain contexts, such as single-application container images that aren’t updated after creation, a distributor may choose not to ship an EXTERNALLY-MANAGED file, so that users can install whatever they like (as they can today) without having to manually override this rule.

One more constraint with PEP 668: [`pip` has decided to lock down user-installed packages as well to preserve each user's `PATH`](https://github.com/pypa/pip/issues/12085#issuecomment-1589417972).

I identified 4 directions we could go:
1. **Continue to use `pipx`**. We started down this road as a quick solution to the problem. I'm pretty disappointed they don't support requirements files, though, so I'd like to explore other options.
1. **Remove `EXTERNALLY-MANAGED`**. This is an INI file located at `sysconfig.get_path("stdlib", sysconfig.get_default_scheme())` (in our case, `/usr/lib/python3.11/EXTERNALLY-MANAGED`). We expect this container to be updated after creation, so we may not want to go this route. Also, it helps that some serious Python developers suggested otherwise.
1. **Circumvent `pip`'s guradrails.** While `pip` tries to support PEP 668 by preventing users from using `pip install --user`, you can run the equivalent command with `--target` instead: `pip install --target $(python -c import site; print(site.USER_BASE)`.
1. **Just do what the developers intend and create a virtual environment**.

We decided to go with the fourth option, especially considering this project will support multiple users.

## Implementation

I had some issues running `./venv/bin/activate` directly. Changing the `PATH` works. I also included setting the `PYTHONPATH` here so we can import `pyopenvdb`