### PR TITLE
NumPy support added to openvdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN git clone https://github.com/AcademySoftwareFoundation/openvdb.git && \
     cd openvdb && \
     mkdir build && \
     cd build && \
-    cmake .. -D OPENVDB_BUILD_PYTHON_MODULE=ON && \
+    cmake .. -D OPENVDB_BUILD_PYTHON_MODULE=ON -D USE_NUMPY=ON && \
     make && \
     make install
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Info
-This is a Dockerfile for the upcoming integration of [OpenVDB](https://www.openvdb.org/) into [Neurovolume](https://github.com/joachimbbp/neurovolume)
+This project is a Dockerfile for [OpenVDB](https://www.openvdb.org/) with `NumPy` support. It is used in [Neurovolume](https://github.com/joachimbbp/neurovolume) but should also be applicable to many scientific visualization projects.
 
-It was made with [Zach Lipp](https://github.com/zachlipp) at the [Recurse Center](https://www.recurse.com/)
+It was made by [Zach Lipp](https://github.com/zachlipp) and Joachim Pfefferkorn (but mostly Zach) at the [Recurse Center](https://www.recurse.com/)
 
 # To Do
 ## Dev and Build


### PR DESCRIPTION
While using this dockerfile in [neurovolume](https://github.com/joachimbbp/neurovolume/)`OpenVDB` originally built without `NumPy` support. This made it unusable for the project's `NIFTI` to `VDB` pipeline.

Adding it to this docker file as I suspect `NumPy` support will be a near-universal need for scientific visualizations.