### PR TITLE
Multi-stage build to reduce Python image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:14.2.0@sha256:4f7f4804d6fa49c371f0f3f54e72a352d865baa6917e79cff63d2b860c53197b
+FROM gcc:14.2.0@sha256:4f7f4804d6fa49c371f0f3f54e72a352d865baa6917e79cff63d2b860c53197b AS builder
 
 RUN apt-get update && \
     apt-get install -y \
@@ -7,33 +7,52 @@ RUN apt-get update && \
     libblosc-dev=1.21.3+ds-1 \
     cmake=3.25.1-1 \
     python3-pybind11=2.10.3-1 \
-    # TODO: Split to multistage build
-    python3-venv=3.11.2-1+b1 \
-    python3-pip=23.0.1+dfsg-1
+    python3-dev=3.11.2-1+b1
 
 RUN git clone https://github.com/AcademySoftwareFoundation/openvdb.git && \
     cd openvdb && \
+    git checkout a759e477aad3f305585ae85c6c723769a7e5f2cf && \
     mkdir build && \
     cd build && \
     cmake .. -D OPENVDB_BUILD_PYTHON_MODULE=ON -D USE_NUMPY=ON && \
     make && \
     make install
 
-RUN useradd -ms /bin/bash nonroot
+FROM python:3.11-slim@sha256:50ec89bdac0a845ec1751f91cb6187a3d8adb2b919d6e82d17acf48d1a9743fc
 
-USER nonroot
+# --- cpp ---
+COPY --from=builder \
+  # openvdb binaries
+  /openvdb/build/openvdb/openvdb/libopenvdb.so* \
+  # build dependencies from ldd
+  /lib/aarch64-linux-gnu/libtbb.so.12 \
+  /lib/aarch64-linux-gnu/libblosc.so.1 \
+  /lib/aarch64-linux-gnu/libz.so.1 \
+  /lib/aarch64-linux-gnu/libboost_iostreams.so.1.74.0 \
+  /lib/aarch64-linux-gnu/libm.so.6 \
+  /lib/aarch64-linux-gnu/liblz4.so.1 \
+  /lib/aarch64-linux-gnu/libsnappy.so.1 \
+  /lib/aarch64-linux-gnu/libzstd.so.1 \
+  /lib/aarch64-linux-gnu/libbz2.so.1.0 \
+  /lib/aarch64-linux-gnu/liblzma.so.5 \
+  /usr/local/lib64/libstdc++.so.6 \
+  /usr/local/lib64/libgcc_s.so.1 \
+  /lib/aarch64-linux-gnu
+
+# --- python ---
+COPY --from=builder \
+  /openvdb/build/openvdb/openvdb/python/pyopenvdb.cpython-311-aarch64-linux-gnu.so /usr/local/lib/python3.11/site-packages/
+
+RUN useradd -ms /bin/bash nonroot
 
 WORKDIR /home/nonroot
 
-COPY neurovolume_deps.txt .
+USER nonroot
 
-# This path doesn't exist yet; we create it in the next layer
-ENV PATH="/home/nonroot/.venv/bin:$PATH"
+COPY neurovolume_deps.txt .
 
 RUN python3 -m venv .venv && \
     # TODO: Parametrize?
     pip install -r neurovolume_deps.txt
 
-ENV PYTHONPATH="/openvdb/build/openvdb/openvdb/python"
-
-ENTRYPOINT [ "sleep", "infinity" ]
+ENTRYPOINT ["sleep", "infinity"]


### PR DESCRIPTION
# Overview
Redesigns the Dockerfile as a [multi-stage](https://docs.docker.com/build/building/multi-stage/) build. Resulting image is over 3x smaller compared to `main` at this time: 3.92GB -> 1.26GB (much of this is from installing `neurovolume_deps.txt`)

## How it works
We bundle everything we need to compile OpenVDB into a Docker image just as before, but now we consider this image as just a temporary filesystem. Once our compilation finishes, we can start over from a smaller image, in this case `python3.11-slim`.

Two interesting things here:
- **What do we need to copy?** This was kind of a pain. It turns out you need to copy the `build` directory (not surprising), but also a) any dynamically linked libraries (discoverable with the tool `ldd`) and b) the cpp binary your build image is using (this probably isn't strictly necessary, but it works well and eliminates a host of compatibility issues). I haven't used `ldd` before. It showed our dependencies were in two directories: `/lib/aarch64-linux-gnu/` and `/usr/local/lib64/`. I thought these might have to match these directories in our new container but they actually didn't work that way. It did work to pile everything into `/lib/aarch64-linux-gnu/`
- **Where should we copy it?** This was fun. This project can work with binaries and Python code anywhere if we set the environment variables `LD_LIBRARY_PATH` and `PYTHONPATH` to specific values. I wanted to get this working without these magic values. This led me to:
  - Put the compiled `ibopenvdb.so*` files and symlinks into `/lib/aarch64-linux-gnu` with all of our other shared libraries (I'm guessing this is the default if `LD_LIBRARY_PATH` is unset)
  - Put the compiled `pyopenvdb.cpython-311-aarch64-linux-gnu.so` into somewhere Python will automatically load it. I opted for `/usr/local/lib/python3.11/site-packages/`, though we could do something with `./local` stuff instead.

One more thing: I checked out the latest commit in `openvdb` after the clone to confirm we're building from a fixed point in time.