### PR TITLE
Support multiple architectures by going back to single-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update && \
     libblosc-dev=1.21.3+ds-1 \
     cmake=3.25.1-1 \
     python3-pybind11=2.10.3-1 \
-    python3-dev=3.11.2-1+b1
+    python3-dev=3.11.2-1+b1 \
+    python3-venv=3.11.2-1+b1 \
+    python3-pip=23.0.1+dfsg-1
 
 RUN git clone https://github.com/AcademySoftwareFoundation/openvdb.git && \
     cd openvdb && \
@@ -18,31 +20,6 @@ RUN git clone https://github.com/AcademySoftwareFoundation/openvdb.git && \
     make && \
     make install
 
-FROM python:3.11-slim@sha256:50ec89bdac0a845ec1751f91cb6187a3d8adb2b919d6e82d17acf48d1a9743fc
-
-# --- cpp ---
-COPY --from=builder \
-  # openvdb binaries
-  /openvdb/build/openvdb/openvdb/libopenvdb.so* \
-  # build dependencies from ldd
-  /lib/aarch64-linux-gnu/libtbb.so.12 \
-  /lib/aarch64-linux-gnu/libblosc.so.1 \
-  /lib/aarch64-linux-gnu/libz.so.1 \
-  /lib/aarch64-linux-gnu/libboost_iostreams.so.1.74.0 \
-  /lib/aarch64-linux-gnu/libm.so.6 \
-  /lib/aarch64-linux-gnu/liblz4.so.1 \
-  /lib/aarch64-linux-gnu/libsnappy.so.1 \
-  /lib/aarch64-linux-gnu/libzstd.so.1 \
-  /lib/aarch64-linux-gnu/libbz2.so.1.0 \
-  /lib/aarch64-linux-gnu/liblzma.so.5 \
-  /usr/local/lib64/libstdc++.so.6 \
-  /usr/local/lib64/libgcc_s.so.1 \
-  /lib/aarch64-linux-gnu/
-
-# --- python ---
-COPY --from=builder \
-  /openvdb/build/openvdb/openvdb/python/pyopenvdb.cpython-311-aarch64-linux-gnu.so /usr/local/lib/python3.11/site-packages/
-
 RUN useradd -ms /bin/bash nonroot
 
 WORKDIR /home/nonroot
@@ -50,6 +27,9 @@ WORKDIR /home/nonroot
 USER nonroot
 
 COPY neurovolume_deps.txt .
+
+# This path doesn't exist yet; we create it in the next layer
+ENV PATH="/home/nonroot/.venv/bin:$PATH"
 
 RUN python3 -m venv .venv && \
     # TODO: Parametrize?

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ COPY --from=builder \
   /lib/aarch64-linux-gnu/liblzma.so.5 \
   /usr/local/lib64/libstdc++.so.6 \
   /usr/local/lib64/libgcc_s.so.1 \
-  /lib/aarch64-linux-gnu \
+  /lib/aarch64-linux-gnu/
+
 # --- python ---
 COPY --from=builder \
   /openvdb/build/openvdb/openvdb/python/pyopenvdb.cpython-311-aarch64-linux-gnu.so /usr/local/lib/python3.11/site-packages/


### PR DESCRIPTION
Normally we'd be catching these locally, but with 1+hr builds, I think we've been reluctant to run full local tests before using CI.

This succeeds locally. We'll see if we need something else for CI

## UPDATE

After in-person discussion, @joachimbbp and I decided we should have a C compiler in our image such that people can reliably install Python packages that build on the host (e.g. `numpy`, `pandas`). This also drastically simplifies multi-architecture support because we're no longer trying to copy and paste from directories that only exist on ARM build targets.